### PR TITLE
New and Renamed Data Types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,9 +138,12 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.15.4"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bytecheck"
@@ -260,6 +263,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base62",
+ "bumpalo",
  "chrono",
  "fraction",
  "rand",

--- a/data_types/Cargo.toml
+++ b/data_types/Cargo.toml
@@ -12,6 +12,10 @@
   rust_decimal = "1.35"
   serde        = { version = "1.0", features = ["derive"] }
 
+  [dependencies.bumpalo]
+    features = ["boxed", "collections", "serde", "std"]
+    version  = "3.16"
+
   [dependencies.uuid]
     features = [
       "fast-rng",          # Use a faster (but still sufficiently random) RNG

--- a/data_types/src/bytes.rs
+++ b/data_types/src/bytes.rs
@@ -1,0 +1,95 @@
+use anyhow::Result;
+use bumpalo::collections::Vec as BumpVec;
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Bytes<'bump> {
+    inner: BumpVec<'bump>,
+    max_capacity: u32,
+}
+
+impl<'bump> Bytes<'bump> {
+    pub fn new(bump: &'bump bumpalo::Bump, value: &[u8], max_capacity: u32) -> Result<Self> {
+        if value.len() > max_capacity as usize {
+            return Err(anyhow::anyhow!("Bytes buffer is full"));
+        }
+
+        let mut bytes = BumpVec::with_capacity_in(value.len(), bump);
+        bytes.extend_from_slice(value);
+
+        Ok(Self {
+            inner: bytes,
+            max_capacity,
+        })
+    }
+
+    #[inline(always)]
+    pub fn from_bytes(bump: &'bump bumpalo::Bump, bytes: &[u8], max_capacity: u32) -> Result<Self> {
+        Self::new(bump, bytes, max_capacity)
+    }
+
+    pub fn into_bytes(self) -> BumpVec<'bump, u8> {
+        self.inner
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.inner.capacity()
+    }
+
+    fn available(&self) -> usize {
+        self.inner.capacity() - self.inner.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    pub fn clear(&mut self) {
+        self.inner.clear();
+    }
+
+    pub fn push_bytes(&mut self, bytes: &[u8]) -> Result<()> {
+        if bytes.len() > self.available() {
+            return Err(anyhow::anyhow!("Bytes buffer is full"));
+        }
+
+        self.inner.push_str(std::str::from_utf8(bytes)?);
+    }
+
+    pub fn range_mut(&mut self, range: std::ops::Range<usize>) -> Result<&mut str> {
+        if range.end > self.len() {
+            return Err(anyhow::anyhow!("Index out of bounds"));
+        }
+
+        Ok(&mut self.inner[range])
+    }
+}
+
+impl<'bump> std::ops::Deref for Bytes<'bump> {
+    type Target = BumpVec<'bump>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<'bump> std::fmt::Debug for Bytes<'bump> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.inner)
+    }
+}
+
+impl<'bump> std::fmt::Display for Bytes<'bump> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.inner)
+    }
+}
+
+impl<'bump> serde::Serialize for Bytes<'bump> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.inner)
+    }
+}

--- a/data_types/src/lib.rs
+++ b/data_types/src/lib.rs
@@ -3,3 +3,28 @@ pub mod oid;
 pub mod ratio;
 pub mod timestamp;
 pub mod uid;
+
+pub enum DataType {
+    Bool,
+    U8,
+    U16,
+    U32,
+    U64,
+    U128,
+    I8,
+    I16,
+    I32,
+    I64,
+    I128,
+    R16,
+    R32,
+    R64,
+    R128,
+    Uid,
+    O16,
+    O32,
+    Decimal,
+    Timestamp,
+    String { max_length: u32 },
+    Bytes { max_length: u32 },
+}

--- a/data_types/src/lib.rs
+++ b/data_types/src/lib.rs
@@ -1,6 +1,8 @@
+pub mod bytes;
 pub mod decimal;
 pub mod oid;
 pub mod ratio;
+pub mod text;
 pub mod timestamp;
 pub mod uid;
 
@@ -25,6 +27,6 @@ pub enum DataType {
     O32,
     Decimal,
     Timestamp,
-    String { max_length: u32 },
+    Text { max_length: u32 },
     Bytes { max_length: u32 },
 }

--- a/data_types/src/oid.rs
+++ b/data_types/src/oid.rs
@@ -1,9 +1,9 @@
 use base62::{decode, encode};
 
 #[derive(Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Oid16(u16);
+pub struct O16(u16);
 
-impl Oid16 {
+impl O16 {
     pub fn new() -> Self {
         Self(rand::random::<u16>())
     }
@@ -25,25 +25,25 @@ impl Oid16 {
     }
 }
 
-impl std::fmt::Debug for Oid16 {
+impl std::fmt::Debug for O16 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", encode(self.0))
     }
 }
 
-impl std::fmt::Display for Oid16 {
+impl std::fmt::Display for O16 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", encode(self.0))
     }
 }
 
-impl serde::Serialize for Oid16 {
+impl serde::Serialize for O16 {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         serializer.serialize_str(&encode(self.0))
     }
 }
 
-impl<'de> serde::Deserialize<'de> for Oid16 {
+impl<'de> serde::Deserialize<'de> for O16 {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let s = String::deserialize(deserializer)?;
 
@@ -52,7 +52,7 @@ impl<'de> serde::Deserialize<'de> for Oid16 {
                 if v > u16::MAX as u128 {
                     Err(serde::de::Error::custom("value out of range"))
                 } else {
-                    Ok(Oid16(v as u16))
+                    Ok(O16(v as u16))
                 }
             }
             Err(e) => Err(serde::de::Error::custom(e.to_string())),
@@ -61,9 +61,9 @@ impl<'de> serde::Deserialize<'de> for Oid16 {
 }
 
 #[derive(Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Oid32(u32);
+pub struct O32(u32);
 
-impl Oid32 {
+impl O32 {
     pub fn new() -> Self {
         Self(rand::random::<u32>())
     }
@@ -85,25 +85,25 @@ impl Oid32 {
     }
 }
 
-impl std::fmt::Debug for Oid32 {
+impl std::fmt::Debug for O32 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", encode(self.0))
     }
 }
 
-impl std::fmt::Display for Oid32 {
+impl std::fmt::Display for O32 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", encode(self.0))
     }
 }
 
-impl serde::Serialize for Oid32 {
+impl serde::Serialize for O32 {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         serializer.serialize_str(&encode(self.0))
     }
 }
 
-impl<'de> serde::Deserialize<'de> for Oid32 {
+impl<'de> serde::Deserialize<'de> for O32 {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let s = String::deserialize(deserializer)?;
 
@@ -112,7 +112,7 @@ impl<'de> serde::Deserialize<'de> for Oid32 {
                 if v > u32::MAX as u128 {
                     Err(serde::de::Error::custom("value out of range"))
                 } else {
-                    Ok(Oid32(v as u32))
+                    Ok(O32(v as u32))
                 }
             }
             Err(e) => Err(serde::de::Error::custom(e.to_string())),

--- a/data_types/src/text.rs
+++ b/data_types/src/text.rs
@@ -1,0 +1,118 @@
+use anyhow::Result;
+use bumpalo::collections::{String as BumpString, Vec as BumpVec};
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Text<'bump> {
+    inner: BumpString<'bump>,
+    max_capacity: u32,
+}
+
+impl<'bump> Text<'bump> {
+    pub fn new(bump: &'bump bumpalo::Bump, value: &str, max_capacity: u32) -> Result<Self> {
+        if value.len() > max_capacity as usize {
+            return Err(anyhow::anyhow!("Text buffer is full"));
+        }
+
+        let mut inner = BumpString::with_capacity_in(max_capacity, bump);
+        inner.push_str(value);
+
+        Ok(Self {
+            inner,
+            max_capacity,
+        })
+    }
+
+    pub fn from_bytes(bump: &'bump bumpalo::Bump, bytes: &[u8], max_capacity: u32) -> Result<Self> {
+        if bytes.len() > max_capacity as usize {
+            return Err(anyhow::anyhow!("Text buffer is full"));
+        }
+
+        let s = std::str::from_utf8(bytes)?;
+
+        let mut inner = BumpString::with_capacity_in(max_capacity, bump);
+        inner.push_str(s);
+
+        Ok(Self {
+            inner,
+            max_capacity,
+        })
+    }
+
+    pub fn into_bytes(self) -> BumpVec<'bump, u8> {
+        self.inner.into_bytes()
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.inner
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.inner.capacity()
+    }
+
+    fn available(&self) -> usize {
+        self.inner.capacity() - self.inner.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    pub fn clear(&mut self) {
+        self.inner.clear();
+    }
+
+    pub fn push_str(&mut self, value: &str) -> Result<()> {
+        if value.len() > self.available() {
+            return Err(anyhow::anyhow!("Text buffer is full"));
+        }
+
+        self.inner.push_str(value);
+    }
+
+    pub fn push_bytes(&mut self, bytes: &[u8]) -> Result<()> {
+        if bytes.len() > self.available() {
+            return Err(anyhow::anyhow!("Text buffer is full"));
+        }
+
+        self.inner.push_str(std::str::from_utf8(bytes)?);
+    }
+
+    pub fn range_mut(&mut self, range: std::ops::Range<usize>) -> Result<&mut str> {
+        if range.end > self.len() {
+            return Err(anyhow::anyhow!("Index out of bounds"));
+        }
+
+        Ok(&mut self.inner[range])
+    }
+}
+
+impl<'bump> std::ops::Deref for Text<'bump> {
+    type Target = BumpString<'bump>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<'bump> std::fmt::Debug for Text<'bump> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.inner)
+    }
+}
+
+impl<'bump> std::fmt::Display for Text<'bump> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.inner)
+    }
+}
+
+impl<'bump> serde::Serialize for Text<'bump> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.inner)
+    }
+}


### PR DESCRIPTION
This pull request refactors the Oid16 and Oid32 structs in the oid.rs file to O16 and O32 respectively. This change improves the clarity and consistency of the codebase. Additionally, it updates the bumpalo dependency to version 3.16.0 and adds the Bytes and Text data types to the data_types module.